### PR TITLE
Deep equal check on state hooks

### DIFF
--- a/custom-ui.js
+++ b/custom-ui.js
@@ -141,9 +141,9 @@ window.customUI = {
                 obj.states,
                 entity
               );
-            if (hass.states && entity !== hass.states[key]) {
+            if (hass.states && JSON.stringify(entity) !== JSON.stringify(hass.states[key])) {
               obj.states[key] = newEntity;
-            } else if (entity !== newEntity) {
+            } else if (JSON.stringify(entity) !== JSON.stringify(newEntity)) {
               obj.states[key] = newEntity;
             }
           });


### PR DESCRIPTION
We currently check for equality of two objects using only `===` which will not work as they are not primitiv values, so we need to deepEqual them. 

The current approach will do many unnecessary updates, and will kind of break the "map" function in home assistant if you have many entities. As the more entities you have, the more the customized `_updateHass` will be called.

I'm not able to zoom in the map, as it keeps bringing me back to the init zoom level, same with moving around the map. It will constantly take me to the default location.

I have tested this PR a while, and I can't see any issue with it. State and icon_colors are updated as they should. 

Fixes #123 